### PR TITLE
Logging Handler

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,3 +7,4 @@ extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373
     E203,
 exclude = .venv
+per-file-ignores = __init__.py:F401

--- a/examples/dictConfig.py
+++ b/examples/dictConfig.py
@@ -1,0 +1,51 @@
+# An example of how to use the scout handler with dictConfig, 
+# useful for early testing 
+
+import logging
+import logging.config
+
+# Example dictConfig
+LOGGING_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "verbose": {
+            "format": "%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s"
+        },
+        "simple": {"format": "%(levelname)s %(message)s"},
+    },
+    "handlers": {
+        "otel": {
+            "level": "DEBUG",
+            "class": "scout_apm_python_logging.OtelScoutHandler",
+            "service_name": "example-python-app",
+        },
+        "console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "simple",
+        },
+    },
+    "loggers": {
+        "root": {
+            "handlers": ["console", "otel"],
+            "level": "DEBUG",
+        },
+    },
+}
+
+# Setup Logging
+logging.config.dictConfig(LOGGING_CONFIG)
+logger = logging.getLogger(__name__)
+
+
+def log_some_stuff():
+    logger.debug("This is a debug message")
+    logger.info("This is an info message")
+    logger.warning("This is a warning message")
+    logger.error("This is an error message")
+    logger.critical("This is a critical message")
+
+
+if __name__ == "__main__":
+    log_some_stuff()

--- a/scout_apm_python_logging/__init__.py
+++ b/scout_apm_python_logging/__init__.py
@@ -1,0 +1,1 @@
+from scout_apm_python_logging.handler import OtelScoutHandler

--- a/scout_apm_python_logging/handler.py
+++ b/scout_apm_python_logging/handler.py
@@ -1,0 +1,62 @@
+import logging
+import os
+from opentelemetry import _logs
+from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
+
+
+class OtelScoutHandler(logging.Handler):
+    def __init__(self, service_name):
+        super().__init__()
+        self.service_name = service_name
+        self.logger_provider = None
+        self.ingest_key = self._get_ingest_key()
+        self.endpoint = self._get_endpoint()
+        self.setup_logging()
+
+    def setup_logging(self):
+        self.logger_provider = LoggerProvider(
+            resource=Resource.create(
+                {
+                    "service.name": self.service_name,
+                    "service.instance.id": os.uname().nodename,
+                }
+            )
+        )
+        _logs.set_logger_provider(self.logger_provider)
+
+        otlp_exporter = OTLPLogExporter(
+            headers={"x-telemetryhub-key": self.ingest_key},
+            endpoint=self.endpoint,
+        )
+        self.logger_provider.add_log_record_processor(
+            BatchLogRecordProcessor(otlp_exporter)
+        )
+
+        self.otel_handler = LoggingHandler(
+            level=logging.NOTSET, logger_provider=self.logger_provider
+        )
+
+    def emit(self, record):
+        print("Emitting log")
+        self.otel_handler.emit(record)
+
+    def close(self):
+        if self.logger_provider:
+            self.logger_provider.shutdown()
+        super().close()
+
+    # These getters will be replaced by a config module to read these values
+    # from a config file or environment variables as the Scout APM agent does.
+    def _get_endpoint(self):
+        return os.getenv(
+            "SCOUT_LOGS_REPORTING_ENDPOINT", "otlp.scoutotel.com:4317"
+        )
+
+    def _get_ingest_key(self):
+        ingest_key = os.getenv("SCOUT_LOGS_INGEST_KEY")
+        if not ingest_key:
+            raise ValueError("SCOUT_LOGS_INGEST_KEY is not set")
+        return ingest_key


### PR DESCRIPTION
## Changes
- Creates a logging handler which is more flexible than a logging setup method. 
- This can be added to a logging setup via `logger.config.dictConfig()`. 
- Adds an example module which does this. Useful for early testing, but will likely be removed in the future. 