### PR TITLE
Add Scout Request Context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Python
 __pycache__/
+.DS_Store
 
 # generated log files
 *.log
@@ -43,3 +44,8 @@ cover/
 # mypy
 .mypy_cache/
 
+# vscode
+settings.json
+
+# env
+.env*

--- a/examples/flask_app.py
+++ b/examples/flask_app.py
@@ -43,7 +43,9 @@ app = Flask(__name__)
 
 # Scout APM configuration
 app.config["SCOUT_NAME"] = "Example Python App"
-app.config["SCOUT_KEY"] = os.environ.get("SCOUT_KEY")  # Make sure to set this environment variable
+app.config["SCOUT_KEY"] = os.environ.get(
+    "SCOUT_KEY"
+)  # Make sure to set this environment variable
 
 # Initialize Scout APM
 ScoutApm(app)
@@ -51,21 +53,25 @@ ScoutApm(app)
 # Get a logger
 logger = logging.getLogger(__name__)
 
-@app.route('/')
+
+@app.route("/")
 def hello():
     logger.info("Received request for hello endpoint")
     return "Hello, World!"
 
-@app.route('/error')
+
+@app.route("/error")
 def error():
     logger.error("This is a test error")
     return "Error logged", 500
 
-@app.route('/debug')
+
+@app.route("/debug")
 def debug():
     logger.debug("This is a debug message")
     return "Debug message logged", 200
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     logger.info("Starting Flask application")
     app.run(debug=True)

--- a/examples/flask_app.py
+++ b/examples/flask_app.py
@@ -1,9 +1,8 @@
 import os
-from flask import Flask, request
+from flask import Flask
 import logging
 from logging.config import dictConfig
 from scout_apm.flask import ScoutApm
-from scout_apm_python_logging import OtelScoutHandler
 
 # Logging configuration
 LOGGING_CONFIG = {

--- a/examples/flask_app.py
+++ b/examples/flask_app.py
@@ -1,0 +1,71 @@
+import os
+from flask import Flask, request
+import logging
+from logging.config import dictConfig
+from scout_apm.flask import ScoutApm
+from scout_apm_python_logging import OtelScoutHandler
+
+# Logging configuration
+LOGGING_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "verbose": {
+            "format": "%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s"
+        },
+        "simple": {"format": "%(levelname)s %(message)s"},
+    },
+    "handlers": {
+        "otel": {
+            "level": "DEBUG",
+            "class": "scout_apm_python_logging.OtelScoutHandler",
+            "service_name": "example-python-app",
+        },
+        "console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "simple",
+        },
+    },
+    "loggers": {
+        "": {  # Root logger
+            "handlers": ["console", "otel"],
+            "level": "DEBUG",
+        },
+    },
+}
+
+# Apply the logging configuration
+dictConfig(LOGGING_CONFIG)
+
+# Create Flask app
+app = Flask(__name__)
+
+# Scout APM configuration
+app.config["SCOUT_NAME"] = "Example Python App"
+app.config["SCOUT_KEY"] = os.environ.get("SCOUT_KEY")  # Make sure to set this environment variable
+
+# Initialize Scout APM
+ScoutApm(app)
+
+# Get a logger
+logger = logging.getLogger(__name__)
+
+@app.route('/')
+def hello():
+    logger.info("Received request for hello endpoint")
+    return "Hello, World!"
+
+@app.route('/error')
+def error():
+    logger.error("This is a test error")
+    return "Error logged", 500
+
+@app.route('/debug')
+def debug():
+    logger.debug("This is a debug message")
+    return "Debug message logged", 200
+
+if __name__ == '__main__':
+    logger.info("Starting Flask application")
+    app.run(debug=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.12"
 opentelemetry-api = "^1.26.0"
 opentelemetry-sdk = "^1.26.0"
 opentelemetry-exporter-otlp = "^1.26.0"
+scout-apm = "^3.1.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ pytest-cov = "^5.0.0"
 flake8 = "^7.1.1"
 flake8-black = "^0.3.6"
 mypy = "^1.11.1"
+flask = "^3.0.3"
 
 [tool.taskipy.tasks]
 test = "pytest . --cov-report=term-missing --cov=."

--- a/scout_apm_python_logging/handler.py
+++ b/scout_apm_python_logging/handler.py
@@ -13,8 +13,8 @@ from scout_apm.core import scout_config
 class OtelScoutHandler(logging.Handler):
     def __init__(self, service_name):
         super().__init__()
-        self.service_name = service_name
         self.logger_provider = None
+        self.service_name = self._get_service_name(service_name)
         self.ingest_key = self._get_ingest_key()
         self.endpoint = self._get_endpoint()
         self.setup_logging()
@@ -85,6 +85,9 @@ class OtelScoutHandler(logging.Handler):
             self.logger_provider.shutdown()
         super().close()
 
+    # These getters will be replaced by a config module to read these values
+    # from a config file or environment variables as the Scout APM agent does.
+
     def _get_service_name(self, provided_name):
         if provided_name:
             return provided_name
@@ -94,11 +97,8 @@ class OtelScoutHandler(logging.Handler):
         if scout_name:
             return scout_name
 
-        # Fallback to a default name if neither is available
         return "unnamed-service"
 
-    # These getters will be replaced by a config module to read these values
-    # from a config file or environment variables as the Scout APM agent does.
     def _get_endpoint(self):
         return (
             scout_config.value("SCOUT_LOGS_REPORTING_ENDPOINT")

--- a/scout_apm_python_logging/handler.py
+++ b/scout_apm_python_logging/handler.py
@@ -45,7 +45,7 @@ class OtelScoutHandler(logging.Handler):
 
     def emit(self, record):
         if getattr(self._handling_log, "value", False):
-            # We're already handling a log message, so don't try to get the TrackedRequest
+            # We're already handling a log message, don't try to get the TrackedRequest
             return self.otel_handler.emit(record)
 
         try:
@@ -64,6 +64,8 @@ class OtelScoutHandler(logging.Handler):
                     record.scout_duration = (
                         scout_request.end_time - scout_request.start_time
                     ).total_seconds()
+
+                record.service_name = self.service_name
 
                 # Add tags
                 for key, value in scout_request.tags.items():
@@ -101,12 +103,11 @@ class OtelScoutHandler(logging.Handler):
 
     def _get_endpoint(self):
         return (
-            scout_config.value("SCOUT_LOGS_REPORTING_ENDPOINT")
-            or "otlp.scoutotel.com:4317"
+            scout_config.value("logs_reporting_endpoint") or "otlp.scoutotel.com:4317"
         )
 
     def _get_ingest_key(self):
-        ingest_key = scout_config.value("SCOUT_LOGS_INGEST_KEY")
+        ingest_key = scout_config.value("logs_ingest_key")
         if not ingest_key:
             raise ValueError("SCOUT_LOGS_INGEST_KEY is not set")
         return ingest_key

--- a/scout_apm_python_logging/handler.py
+++ b/scout_apm_python_logging/handler.py
@@ -48,7 +48,7 @@ class OtelScoutHandler(logging.Handler):
         if self.should_ignore_log(record):
             return
 
-        if getattr(self._handling_log, 'value', False):
+        if getattr(self._handling_log, "value", False):
             # We're already handling a log message, so don't try to get the TrackedRequest
             return self.otel_handler.emit(record)
 
@@ -66,11 +66,12 @@ class OtelScoutHandler(logging.Handler):
                 # Add duration if the request is completed
                 if scout_request.end_time:
                     record.scout_duration = (
-                        scout_request.end_time - scout_request.start_time).total_seconds()
+                        scout_request.end_time - scout_request.start_time
+                    ).total_seconds()
 
                 # Add tags
                 for key, value in scout_request.tags.items():
-                    setattr(record, f'scout_tag_{key}', value)
+                    setattr(record, f"scout_tag_{key}", value)
 
                 # Add the current span's operation if available
                 current_span = scout_request.current_span()
@@ -103,10 +104,11 @@ class OtelScoutHandler(logging.Handler):
 
     def should_ignore_log(self, record):
         # Ignore logs from the OpenTelemetry exporter
-        if record.name.startswith('opentelemetry.exporter.otlp'):
+        if record.name.startswith("opentelemetry.exporter.otlp"):
             return True
-        
+
         return False
+
     def close(self):
         if self.logger_provider:
             self.logger_provider.shutdown()
@@ -117,19 +119,18 @@ class OtelScoutHandler(logging.Handler):
             return provided_name
 
         # Try to get the name from Scout APM config
-        scout_name = scout_config.value('name')
+        scout_name = scout_config.value("name")
         if scout_name:
             return scout_name
 
         # Fallback to a default name if neither is available
         return "unnamed-service"
+
     # These getters will be replaced by a config module to read these values
     # from a config file or environment variables as the Scout APM agent does.
 
     def _get_endpoint(self):
-        return os.getenv(
-            "SCOUT_LOGS_REPORTING_ENDPOINT", "otlp.scoutotel.com:4317"
-        )
+        return os.getenv("SCOUT_LOGS_REPORTING_ENDPOINT", "otlp.scoutotel.com:4317")
 
     def _get_ingest_key(self):
         ingest_key = os.getenv("SCOUT_LOGS_INGEST_KEY")


### PR DESCRIPTION
## Changes
- Integrate with `scout_apm` python agent to get the TrackedRequest on log emit. Sets a threading.local `handling_job` value so we don't recursively try to create new TrackedRequests on initial startup. 
- Pulls some values from the scout_request, including any custom set tags. 
- Adds an example flask app which adds scout and scout_logging. These kind of thing can eventually be wrapped into some integration tests, for this is helpful for local development for now. 