### PR TITLE
support getting ingest key from django

### DIFF
--- a/scout_apm_python_logging/handler.py
+++ b/scout_apm_python_logging/handler.py
@@ -109,5 +109,17 @@ class OtelScoutHandler(logging.Handler):
     def _get_ingest_key(self):
         ingest_key = scout_config.value("logs_ingest_key")
         if not ingest_key:
-            raise ValueError("SCOUT_LOGS_INGEST_KEY is not set")
+            try:
+                from django.conf import settings
+
+                ingest_key = getattr(settings, "SCOUT_LOGS_INGEST_KEY", None)
+            except ImportError:
+                pass
+
+        if not ingest_key:
+            raise ValueError(
+                "SCOUT_LOGS_INGEST_KEY is not set, please do so in \
+                             your environment or django config file"
+            )
+
         return ingest_key


### PR DESCRIPTION
## Changes
- Supports getting ingest key from the django `settings.py` file. The scout agent does already do this for all `SCOUT_` prepended values and add those values into the `scount_config` module level values. However, because the logging is configured on startup, this can happen before the scout agent has a chance to set those values. 