### PR TITLE
Attach controller endpoint to log

### DIFF
--- a/scout_apm_python_logging/handler.py
+++ b/scout_apm_python_logging/handler.py
@@ -116,16 +116,8 @@ class OtelScoutHandler(logging.Handler):
                 if span.operation.startswith("Controller/"):
                     return span.operation
 
-        try:
-            return (
-                record.operation
-                # Check for type to support test mocks
-                if type(record.operation) is str
-                else from_spans(record)
-            )
-        except AttributeError:
-            # TrackedRequest.operation will only exist on scout_apm > 3.2.0
-            return from_spans(record)
+        operation = getattr(record, "operation", None)
+        return operation if operation else from_spans(record)
 
     def _get_ingest_key(self):
         ingest_key = scout_config.value("logs_ingest_key")

--- a/scout_apm_python_logging/handler.py
+++ b/scout_apm_python_logging/handler.py
@@ -117,14 +117,15 @@ class OtelScoutHandler(logging.Handler):
                     return span.operation
 
         try:
-            # TrackedRequest.operation will only exist on scout_apm > 3.2.0
             return (
                 record.operation
+                # Check for type to support test mocks
                 if type(record.operation) is str
                 else from_spans(record)
             )
         except AttributeError:
-            pass
+            # TrackedRequest.operation will only exist on scout_apm > 3.2.0
+            return from_spans(record)
 
     def _get_ingest_key(self):
         ingest_key = scout_config.value("logs_ingest_key")

--- a/scout_apm_python_logging/handler.py
+++ b/scout_apm_python_logging/handler.py
@@ -53,7 +53,7 @@ class OtelScoutHandler(logging.Handler):
             scout_request = TrackedRequest.instance()
 
             if scout_request:
-                self._get_operation_name(scout_request)
+                record.operation = self._get_operation_name(scout_request)
 
                 # Add Scout-specific attributes to the log record
                 record.scout_request_id = scout_request.request_id
@@ -109,7 +109,7 @@ class OtelScoutHandler(logging.Handler):
         )
 
     def _get_operation_name(self, record: TrackedRequest):
-        # Iterate backwards since with the controller name 
+        # Iterate backwards since with the controller name
         # will be near the end of the list
         for span in record.complete_spans[::-1]:
             if span.operation.startswith("Controller/"):

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -57,6 +57,41 @@ def test_emit_with_scout_request(mock_tracked_request, otel_scout_handler):
 
 
 @patch("scout_apm_python_logging.handler.TrackedRequest")
+def test_emit_when_scout_request_contains_operation(
+    mock_tracked_request, otel_scout_handler
+):
+    mock_request = MagicMock()
+    mock_request.request_id = "test-id"
+    mock_request.start_time.isoformat.return_value = "2024-03-06T12:00:00"
+    mock_request.end_time.isoformat.return_value = "2024-03-06T12:00:01"
+    mock_request.tags = {"key": "value"}
+    mock_request.complete_spans = [
+        Span(mock_request.id, "Middleware"),
+    ]
+    mock_request.operation = MagicMock().return_value = "Controller/foobar"
+    mock_tracked_request.instance.return_value = mock_request
+
+    with patch.object(otel_scout_handler, "otel_handler") as mock_otel_handler:
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+        otel_scout_handler.emit(record)
+
+        mock_otel_handler.emit.assert_called_once()
+        assert record.scout_request_id == "test-id"
+        assert record.scout_start_time == "2024-03-06T12:00:00"
+        assert record.scout_end_time == "2024-03-06T12:00:01"
+        assert record.scout_tag_key == "value"
+        assert record.operation == "Controller/foobar"
+
+
+@patch("scout_apm_python_logging.handler.TrackedRequest")
 def test_emit_without_scout_request(mock_tracked_request, otel_scout_handler):
     mock_tracked_request.instance.return_value = None
     with patch.object(otel_scout_handler, "otel_handler") as mock_otel_handler:

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -30,6 +30,7 @@ def test_emit_with_scout_request(mock_tracked_request, otel_scout_handler):
     mock_request.start_time.isoformat.return_value = "2024-03-06T12:00:00"
     mock_request.end_time.isoformat.return_value = "2024-03-06T12:00:01"
     mock_request.tags = {"key": "value"}
+    mock_request.operation = None
     mock_request.complete_spans = [
         Span(mock_request.id, "Middleware"),
         Span(mock_request.id, "Controller/foobar"),


### PR DESCRIPTION
## Changes
- Gets the "Endpoint"/"Controller" value from the tracked request and attaches this to the log record. 
- The Scout python agent creates a span with the "operation" name set to a value with the shape of `Controller/` for each of the supported frameworks.
- We iterate though the completed spans to find this span. 

## Update
- We updated the Python agent to include an `operation` property on the TrackedRequest class. This is more efficient than iterating through the completed spans to find the one which contains the "Controller" or "Job". This will be supported in scout_apm > 3.2.0. 
- If clients have not updated scout_apm agent, we will fallback to getting the operation from the completed spans. 