### PR TITLE
update pyproject with maintainers and urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,14 @@
 [tool.poetry]
 name = "scout-apm-logging"
 version = "1.0.0"
-description = "Scout APM Python Logging Agent"
+description = "Opentelemetry logging integration for Scout APM"
 authors = ["Quinn Milionis <quinn@scoutapm.com>"]
+maintainers = ["Scout <support@scoutapm.com>"]
 readme = "README.md"
-
+urls = {
+    "github": "https://github.com/scoutapp/scout_apm_python_logging"
+    "scout": "https://scoutapm.com"
+}
 [tool.poetry.dependencies]
 python = "^3.9"
 opentelemetry-api = "^1.26.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,17 +5,18 @@ description = "Opentelemetry logging integration for Scout APM"
 authors = ["Quinn Milionis <quinn@scoutapm.com>"]
 maintainers = ["Scout <support@scoutapm.com>"]
 readme = "README.md"
-urls = {
-    "github": "https://github.com/scoutapp/scout_apm_python_logging"
-    "scout": "https://scoutapm.com"
-}
+
+[tool.poetry.urls]
+homepage = "https://scoutapm.com"
+documentation = "https://scoutapm.com/docs/features/log-management"
+repository = "https://github.com/scoutapp/scout_apm_python_logging"
+
 [tool.poetry.dependencies]
 python = "^3.9"
 opentelemetry-api = "^1.26.0"
 opentelemetry-sdk = "^1.26.0"
 opentelemetry-exporter-otlp = "^1.26.0"
 scout-apm = "^3.1.0"
-
 
 [tool.poetry.group.dev.dependencies]
 taskipy = "^1.13.0"


### PR DESCRIPTION
## Changes
- Adds Scout as a maintainer. 
- Adds associated URLs. 


URLs are added following the documentation here: https://python-poetry.org/docs/pyproject/#urls
I was expecting this to add the "project links" section to the pypi page, but they are not visible in at https://test.pypi.org/project/scout-apm-logging/

So I wonder if these will not be visible until a version is released. Anyone know about this? 