### PR TITLE
Django configuration compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,15 @@
 [tool.poetry]
 name = "scout-apm-logging"
-version = "1.0.0"
+version = "1.0.1"
 description = "Scout APM Python Logging Agent"
-authors = ["Quinn Milionis <quinn@scoutapm.com>"]
+authors = ["Scout <support@scoutapm.com>"]
+maintainers = ["Quinn Milionis <quinn@scoutapm.com>"]
 readme = "README.md"
+
+[tool.poetry.urls]
+homepage = "https://scoutapm.com"
+repository = "https://github.com/scoutapp/scout_apm_python_logging"
+documentation = "https://scoutapm.com/docs/features/log-management"
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/scout_apm_logging/handler.py
+++ b/scout_apm_logging/handler.py
@@ -69,9 +69,6 @@ class ScoutOtelHandler(logging.Handler):
                     print(f"Failed to initialize ScoutOtelHandler: {e}")
                     return
 
-            if not self.otel_handler:
-                return
-
             if getattr(self._handling_log, "value", False):
                 # We're already handling a log message, don't get the TrackedRequest
                 return self.otel_handler.emit(record)

--- a/scout_apm_logging/handler.py
+++ b/scout_apm_logging/handler.py
@@ -61,7 +61,6 @@ class ScoutOtelHandler(logging.Handler):
 
     def emit(self, record):
         try:
-            self._handling_log.value = True
             # Initialize here to ensure that required configuration variables are loaded
             if not ScoutOtelHandler._class_initialized:
                 try:
@@ -76,6 +75,8 @@ class ScoutOtelHandler(logging.Handler):
             if getattr(self._handling_log, "value", False):
                 # We're already handling a log message, don't get the TrackedRequest
                 return self.otel_handler.emit(record)
+
+            self._handling_log.value = True
             scout_request = TrackedRequest.instance()
 
             if scout_request:

--- a/scout_apm_logging/handler.py
+++ b/scout_apm_logging/handler.py
@@ -12,14 +12,12 @@ from scout_apm_logging.utils.operation_utils import get_operation_detail
 
 
 class ScoutOtelHandler(logging.Handler):
-    # Flag to prevent multiple initializations
-    _class_initialized = False
     _initialization_lock = threading.Lock()
+    otel_handler = None
 
     def __init__(self, service_name):
         super().__init__()
         self.logger_provider = None
-        self.otel_handler = None
         self.service_name = service_name
         self._handling_log = threading.local()
         self._initialized = False
@@ -27,16 +25,15 @@ class ScoutOtelHandler(logging.Handler):
 
     def _initialize(self):
         with self._initialization_lock:
-            if ScoutOtelHandler._class_initialized:
+            if ScoutOtelHandler.otel_handler:
                 return
 
             self.service_name = self._get_service_name(self.service_name)
             self.ingest_key = self._get_ingest_key()
             self.endpoint = self._get_endpoint()
-            self.setup_logging()
-            ScoutOtelHandler._class_initialized = True
+            self.setup_otel_handler()
 
-    def setup_logging(self):
+    def setup_otel_handler(self):
         self.logger_provider = LoggerProvider(
             resource=Resource.create(
                 {
@@ -55,62 +52,57 @@ class ScoutOtelHandler(logging.Handler):
             BatchLogRecordProcessor(otlp_exporter)
         )
 
-        self.otel_handler = LoggingHandler(
+        ScoutOtelHandler.otel_handler = LoggingHandler(
             level=logging.NOTSET, logger_provider=self.logger_provider
         )
 
     def emit(self, record):
-        try:
-            # Initialize here to ensure that required configuration variables are loaded
-            if not ScoutOtelHandler._class_initialized:
-                try:
-                    self._initialize()
-                except Exception as e:
-                    print(f"Failed to initialize ScoutOtelHandler: {e}")
-                    return
+        if not ScoutOtelHandler.otel_handler:
+            try:
+                self._initialize()
+            except Exception as e:
+                print(f"Failed to initialize ScoutOtelHandler: {e}")
+                return
 
-            if getattr(self._handling_log, "value", False):
-                # We're already handling a log message, don't get the TrackedRequest
-                return self.otel_handler.emit(record)
+        if getattr(self._handling_log, "value", False):
+            # We're already handling a log message, don't get the TrackedRequest
+            return ScoutOtelHandler.otel_handler.emit(record)
 
-            self._handling_log.value = True
-            scout_request = TrackedRequest.instance()
+        self._handling_log.value = True
+        scout_request = TrackedRequest.instance()
 
-            if scout_request:
-                operation_detail = get_operation_detail(scout_request)
-                if operation_detail:
-                    setattr(
-                        record,
-                        operation_detail.entrypoint_attribute,
-                        operation_detail.name,
-                    )
+        if scout_request:
+            operation_detail = get_operation_detail(scout_request)
+            if operation_detail:
+                setattr(
+                    record,
+                    operation_detail.entrypoint_attribute,
+                    operation_detail.name,
+                )
 
-                # Add Scout-specific attributes to the log record
-                record.scout_request_id = scout_request.request_id
-                record.scout_start_time = scout_request.start_time.isoformat()
-                # Add duration if the request is completed
-                if scout_request.end_time:
-                    record.scout_end_time = scout_request.end_time.isoformat()
-                    record.scout_duration = (
-                        scout_request.end_time - scout_request.start_time
-                    ).total_seconds()
+            # Add Scout-specific attributes to the log record
+            record.scout_request_id = scout_request.request_id
+            record.scout_start_time = scout_request.start_time.isoformat()
+            # Add duration if the request is completed
+            if scout_request.end_time:
+                record.scout_end_time = scout_request.end_time.isoformat()
+                record.scout_duration = (
+                    scout_request.end_time - scout_request.start_time
+                ).total_seconds()
 
-                setattr(record, "service.name", self.service_name)
+            setattr(record, "service.name", self.service_name)
 
-                # Add tags
-                for key, value in scout_request.tags.items():
-                    setattr(record, f"scout_tag_{key}", value)
+            # Add tags
+            for key, value in scout_request.tags.items():
+                setattr(record, f"scout_tag_{key}", value)
 
-                # Add the current span's operation if available
-                current_span = scout_request.current_span()
-                if current_span:
-                    record.scout_current_operation = current_span.operation
+            # Add the current span's operation if available
+            current_span = scout_request.current_span()
+            if current_span:
+                record.scout_current_operation = current_span.operation
 
-            self.otel_handler.emit(record)
-        except Exception as e:
-            print(f"Error in ScoutOtelHandler.emit: {e}")
-        finally:
-            self._handling_log.value = False
+        ScoutOtelHandler.otel_handler.emit(record)
+        self._handling_log.value = False
 
     def close(self):
         if self.logger_provider:

--- a/scout_apm_logging/handler.py
+++ b/scout_apm_logging/handler.py
@@ -12,14 +12,29 @@ from scout_apm_logging.utils.operation_utils import get_operation_detail
 
 
 class ScoutOtelHandler(logging.Handler):
+    # Flag to prevent multiple initializations
+    _class_initialized = False
+    _initialization_lock = threading.Lock()
+
     def __init__(self, service_name):
         super().__init__()
         self.logger_provider = None
-        self.service_name = self._get_service_name(service_name)
-        self.ingest_key = self._get_ingest_key()
-        self.endpoint = self._get_endpoint()
-        self.setup_logging()
+        self.otel_handler = None
+        self.service_name = service_name
         self._handling_log = threading.local()
+        self._initialized = False
+        self._initializing = False
+
+    def _initialize(self):
+        with self._initialization_lock:
+            if ScoutOtelHandler._class_initialized:
+                return
+
+            self.service_name = self._get_service_name(self.service_name)
+            self.ingest_key = self._get_ingest_key()
+            self.endpoint = self._get_endpoint()
+            self.setup_logging()
+            ScoutOtelHandler._class_initialized = True
 
     def setup_logging(self):
         self.logger_provider = LoggerProvider(
@@ -45,12 +60,22 @@ class ScoutOtelHandler(logging.Handler):
         )
 
     def emit(self, record):
-        if getattr(self._handling_log, "value", False):
-            # We're already handling a log message, don't try to get the TrackedRequest
-            return self.otel_handler.emit(record)
-
         try:
             self._handling_log.value = True
+            # Initialize here to ensure that required configuration variables are loaded
+            if not ScoutOtelHandler._class_initialized:
+                try:
+                    self._initialize()
+                except Exception as e:
+                    print(f"Failed to initialize ScoutOtelHandler: {e}")
+                    return
+
+            if not self.otel_handler:
+                return
+
+            if getattr(self._handling_log, "value", False):
+                # We're already handling a log message, don't get the TrackedRequest
+                return self.otel_handler.emit(record)
             scout_request = TrackedRequest.instance()
 
             if scout_request:
@@ -65,11 +90,9 @@ class ScoutOtelHandler(logging.Handler):
                 # Add Scout-specific attributes to the log record
                 record.scout_request_id = scout_request.request_id
                 record.scout_start_time = scout_request.start_time.isoformat()
-                if scout_request.end_time:
-                    record.scout_end_time = scout_request.end_time.isoformat()
-
                 # Add duration if the request is completed
                 if scout_request.end_time:
+                    record.scout_end_time = scout_request.end_time.isoformat()
                     record.scout_duration = (
                         scout_request.end_time - scout_request.start_time
                     ).total_seconds()

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -7,14 +7,16 @@ from scout_apm.core.tracked_request import Span
 
 
 @pytest.fixture
-def otel_scout_handler():
+@patch("scout_apm_logging.handler.scout_config")
+def otel_scout_handler(mock_scout_config):
+    mock_scout_config.value.return_value = "test-ingest-key"
     with patch("scout_apm_logging.handler.OTLPLogExporter"), patch(
         "scout_apm_logging.handler.LoggerProvider"
     ), patch("scout_apm_logging.handler.BatchLogRecordProcessor"), patch(
         "scout_apm_logging.handler.Resource"
     ):
         handler = ScoutOtelHandler(service_name="test-service")
-        yield handler
+        return handler
 
 
 def test_init(otel_scout_handler):


### PR DESCRIPTION
## Changes
- Fixes an issue where configuration from the Django `settings.py` was not loaded by the time the handler was initialized, which would result in failed startup.
- Now, the handler waits to initialize until the first time emit is called.
- Since the initialization process can itself emit log messages, this can cause infinite recursion, so to avoid this, we add a flag to check for an initialization in-progress to avoid the multiple init calls which are made when django sets up logging. We use a thread thread lock to further guard against recursion/race conditions. 

## Notes
- This is hardly the most elegant solution. The _proper_ way to do a django logger is probably be the package to be added an an app and/or middleware. Still, this does work, and is sufficient for the time being. 