### PR TITLE
Derive operation from active spans

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scout-apm-logging"
-version = "1.0.1"
+version = "1.0.2"
 description = "Scout APM Python Logging Agent"
 authors = ["Scout <support@scoutapm.com>"]
 maintainers = ["Quinn Milionis <quinn@scoutapm.com>"]

--- a/scout_apm_logging/utils/operation_utils.py
+++ b/scout_apm_logging/utils/operation_utils.py
@@ -39,7 +39,7 @@ def get_operation_detail(record: TrackedRequest) -> Optional[OperationDetail]:
         return extract_operation(operation)
 
     # Fall back to checking spans
-    spans = getattr(record, "complete_spans", None) or []
+    spans = getattr(record, "active_spans", None) or []
     for span in reversed(spans):
         result = extract_operation(span.operation)
         if result:

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -40,7 +40,7 @@ def test_emit_with_scout_request(mock_tracked_request, otel_scout_handler):
     mock_request.end_time.isoformat.return_value = "2024-03-06T12:00:01"
     mock_request.tags = {"key": "value"}
     mock_request.operation = None
-    mock_request.complete_spans = [
+    mock_request.active_spans = [
         Span(mock_request.id, "Middleware"),
         Span(mock_request.id, "Controller/foobar"),
     ]
@@ -75,7 +75,7 @@ def test_emit_when_scout_request_contains_operation(
     mock_request.start_time.isoformat.return_value = "2024-03-06T12:00:00"
     mock_request.end_time.isoformat.return_value = "2024-03-06T12:00:01"
     mock_request.tags = {"key": "value"}
-    mock_request.complete_spans = [
+    mock_request.active_spans = [
         Span(mock_request.id, "Middleware"),
     ]
     mock_request.operation = MagicMock().return_value = "Controller/foobar"

--- a/tests/unit/test_operation_utils.py
+++ b/tests/unit/test_operation_utils.py
@@ -15,7 +15,7 @@ class MockSpan:
 @dataclass
 class MockTrackedRequest:
     operation: Optional[str] = None
-    complete_spans: Optional[List[MockSpan]] = None
+    active_spans: Optional[List[MockSpan]] = None
 
 
 def test_operation_detail_entrypoint_attribute():
@@ -37,7 +37,7 @@ def test_get_operation_detail_from_spans():
         MockSpan(operation="Job/TestJob"),
         MockSpan(operation="Controller/TestController"),
     ]
-    record = MockTrackedRequest(complete_spans=spans)
+    record = MockTrackedRequest(active_spans=spans)
     result = get_operation_detail(record)
     assert result == OperationDetail(
         name="TestController", type=OperationType.CONTROLLER
@@ -63,7 +63,7 @@ def test_get_operation_detail_no_operation_or_spans():
 
 
 def test_get_operation_detail_empty_spans():
-    record = MockTrackedRequest(complete_spans=[])
+    record = MockTrackedRequest(active_spans=[])
     result = get_operation_detail(record)
     assert result is None
 
@@ -73,7 +73,7 @@ def test_get_operation_detail_spans_no_match():
         MockSpan(operation="Other/Operation1"),
         MockSpan(operation="Other/Operation2"),
     ]
-    record = MockTrackedRequest(complete_spans=spans)
+    record = MockTrackedRequest(active_spans=spans)
     result = get_operation_detail(record)
     assert result is None
 
@@ -81,7 +81,7 @@ def test_get_operation_detail_spans_no_match():
 def test_get_operation_detail_operation_priority():
     spans = [MockSpan(operation="Job/TestJob")]
     record = MockTrackedRequest(
-        operation="Controller/TestController", complete_spans=spans
+        operation="Controller/TestController", active_spans=spans
     )
     result = get_operation_detail(record)
     assert result == OperationDetail(


### PR DESCRIPTION
Gets operation from the `active_spans` array on the tracked_request object. This will fix compatibility with users on older versions of the scout-apm package. 