### PR TITLE
bump version to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
 ## Pending
+
+## [1.0.2] 2025-12-05
 ### Changed
-- Rename `scout_request_id` log attribute to `scout_transaction_id` for compatability (#28)
+- Rename `scout_request_id` log attribute to `scout_transaction_id` for compatibility (#28)
 
 ## [1.0.1] 2024-09-12
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scout-apm-logging"
-version = "1.0.1"
+version = "1.0.2"
 description = "Scout APM Python Logging Agent"
 authors = ["Scout <support@scoutapm.com>"]
 maintainers = ["Quinn Milionis <quinn@scoutapm.com>"]


### PR DESCRIPTION
## Changes
- bump version to release change to `scout_transaction_id` from `scout_request_id`
