### PR TITLE
Drop python 3.9, add 3.13 and 3.14 to workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,12 +3,12 @@ name: Test and Lint
 on:
   pull_request:
 
-jobs: 
+jobs:
   test-and-lint:
     runs-on: ubuntu-latest
-    strategy: 
-      matrix: 
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     env:
       SCOUT_LOGS_INGEST_KEY: test-ingest-key
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## Pending
+### Fixed
+- Shared logger provider being closed prematurely (#32)
+- Ensure `handling_log` set to false if emit fails
+
+### Changed
+- Drop Python 3.9 support, add Python 3.13 and 3.14 support (#33)
 
 ## [1.0.2] 2025-12-05
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/scoutapp/scout_apm_python_logging"
 documentation = "https://scoutapm.com/docs/features/log-management"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 opentelemetry-api = "^1.26.0"
 opentelemetry-sdk = "^1.26.0"
 opentelemetry-exporter-otlp = "^1.26.0"


### PR DESCRIPTION
## Changes
- Drops end-of-life python 3.9 from workflow, adds 3.13 and 3.14 
